### PR TITLE
[PS-794] Add pagination to param lookup

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ async function run_action() {
     try {
       core.info('Fetching parameters from AWS...')
       const result = await fetchParameters(path, decryption)
+      core.info(result)
       const parameters = result.Parameters
       core.info(`Fetched ${parameters.length} parameters.`)
       SetEnvironmentVariables(parameters, prefix)

--- a/index.js
+++ b/index.js
@@ -2,8 +2,6 @@ const core = require('@actions/core');
 const AWS = require('aws-sdk');
 
 const role_arn = process.env.AWS_ROLE_ARN;
-const assume_role_credentials = await getAssumeRoleCredentials(role_arn);
-const ssm = new AWS.SSM(assume_role_credentials);
 
 run_action();
 
@@ -29,6 +27,9 @@ async function run_action() {
 }
 
 const fetchParameters = async (path, withDecryption = true, params = [], nextToken = undefined) => {
+  const assume_role_credentials = await getAssumeRoleCredentials(role_arn);
+  const ssm = new AWS.SSM(assume_role_credentials);
+
   return ssm
     .getParametersByPath({ Path: path, Recursive: true, WithDecryption: withDecryption, NextToken: nextToken, MaxResults: 10 })
     .promise()

--- a/index.js
+++ b/index.js
@@ -9,8 +9,7 @@ async function run_action() {
 
     try {
       core.info('Fetching parameters from AWS...')
-      const result = await fetchParameters(path, decryption)
-      const parameters = result.Parameters
+      const parameters = await fetchParameters(path, decryption)
       core.info(`Fetched ${parameters.length} parameters.`)
       SetEnvironmentVariables(parameters, prefix)
     } catch (e) {

--- a/index.js
+++ b/index.js
@@ -10,7 +10,6 @@ async function run_action() {
     try {
       core.info('Fetching parameters from AWS...')
       const result = await fetchParameters(path, decryption)
-      core.info(result)
       const parameters = result.Parameters
       core.info(`Fetched ${parameters.length} parameters.`)
       SetEnvironmentVariables(parameters, prefix)

--- a/index.js
+++ b/index.js
@@ -3,8 +3,6 @@ const AWS = require('aws-sdk');
 
 const role_arn = process.env.AWS_ROLE_ARN;
 
-run_action();
-
 async function run_action() {
   try {
     const path = core.getInput('path', {required: true});
@@ -87,3 +85,5 @@ const getAssumeRoleCredentials = async (role_arn) => {
     });
   });
 }
+
+run_action();

--- a/index.js
+++ b/index.js
@@ -1,8 +1,6 @@
 const core = require('@actions/core');
 const AWS = require('aws-sdk');
 
-const role_arn = process.env.AWS_ROLE_ARN;
-
 async function run_action() {
   try {
     const path = core.getInput('path', {required: true});
@@ -25,6 +23,7 @@ async function run_action() {
 }
 
 const fetchParameters = async (path, withDecryption = true, params = [], nextToken = undefined) => {
+  const role_arn = process.env.AWS_ROLE_ARN;
   const assume_role_credentials = await getAssumeRoleCredentials(role_arn);
   const ssm = new AWS.SSM(assume_role_credentials);
 

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ const fetchParameters = async (path, withDecryption = true, params = [], nextTok
     .promise()
     .then(({ Parameters, NextToken }) => {
       const moreParams = params.concat(Parameters);
-      return NextToken ? fetchRecursively(path, withDecryption, moreParams, NextToken) : moreParams;
+      return NextToken ? fetchParameters(path, withDecryption, moreParams, NextToken) : moreParams;
     });
 }
 


### PR DESCRIPTION
## Context
The [`getParametersByPath`](https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_GetParametersByPath.html) API call returns a max of 10 parameters, so we need to be able to paginate through these to get anything more than 10