### PR TITLE
[PS-877] Replace dashes with underscores and set uppercase

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ function SetEnvironmentVariables(parameters, prefix) {
 
 function formatName(name, prefix) {
   const split = name.split('/');
-  return prefix + split[split.length - 1];
+  return prefix + split[split.length - 1].replace('-', '_').toUpperCase();
 }
 
 function setEnvironmentVar(key, value, secret) {


### PR DESCRIPTION
## Context
If we save environment variables in SSM with dashes, they're invalid within the GHA workflow run.

e.g. a secret stored in SSM Param store with a key of `/my-app/the-db-password` results in an environment variable in GHA as `$the-db-password`...which is invalid as it contains a dash `-` character.

This PR replaces dashes with underscores to fix the problem, and also sets the env var to uppercase for easier reading.